### PR TITLE
Ensure that `myX` is a data frame

### DIFF
--- a/R/MORE_GLM.R
+++ b/R/MORE_GLM.R
@@ -1720,7 +1720,7 @@ BetaTest = function(coeffs, myGene, MOREresults){
       mySigni = gsub("`", "", mySignificatives)
       myY = MOREresults$ResultsPerGene[[myGene]]$Y[,1]
       myX = MOREresults$ResultsPerGene[[myGene]]$X
-      myX = myX[, mySigni]
+      myX = myX[, mySigni, drop = FALSE]
 
       for(i in 1:nrow(betas)){
 


### PR DESCRIPTION
Hi,

This PR fixes a bug which gave us trouble when running `RegulationPerCondition()`: 
``` r
res = GetGLM(...)

RegulationPerCondition(res, betaTest = T)
#> Error in model.frame.default(formula = myY ~ ., data = myX, drop.unused.levels = TRUE): 
#>  'data' must be a data.frame, environment, or list
```
I traced the error to `BetaTest()`, where the subsetting variable `mySigni` had length 1 in our case. The suggested fix ensures that the `myX` stays a data frame after subsetting, rather than being reduced to a vector.

(I would normally include a complete reprex, but I struggled to reduce our dataset while maintaining the error...if you insist I'll give it another go.)

Many thanks for a useful package!
Magnus