### PR TITLE
Collinearity filter only if there is more than one regulator for a gene

### DIFF
--- a/R/MORE_GLM.R
+++ b/R/MORE_GLM.R
@@ -461,9 +461,13 @@ GetGLM = function(GeneExpression,
       }
       else {  ## Regulators for the model!!
 
-        ## Multicollinearity
-        res = CollinearityFilter(data = res$RegulatorMatrix, reg.table = res$SummaryPerGene,
+        ## Apply multicollinearity filter only if there is more than one regulator for a gene
+        
+        if (ncol(res$RegulatorMatrix)>1){
+          
+          res = CollinearityFilter(data = res$RegulatorMatrix, reg.table = res$SummaryPerGene,
                                  correlation = correlation, omic.type = omic.type)
+        }
 
         ResultsPerGene[[i]]$allRegulators = res$SummaryPerGene
 


### PR DESCRIPTION
Apply multicollinearity filter only if a gene presents more than one potential regulator, otherwise it makes no sense to apply it.